### PR TITLE
Link zum Bild korrigiert

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,5 +17,5 @@ Although hurt, Bajaja defeats the dragon, but an evil knight takes credit for th
 > Take this you stupid dragon. 
 > Do not dare to come back. 
 
-<img src="https://de.depositphotos.com/stock-photos/prince-horse.html?qview=52446905"/>
+<img src="https://st2.depositphotos.com/1756323/5244/i/950/depositphotos_52446905-stock-photo-fantasy-prince-on-a-horse.jpg"/>
 


### PR DESCRIPTION
Wie ich's gemacht habe:

* Rechtsklick auf das "Bild" von https://astriduser.github.io/ -> "Bild in neuem Tab oeffnen"
* Auf der sich oeffnenden Webseite auf das Bild klicken
* auf das nun vergroessert dargestellte Bild wieder rechtsklicken -> "Bild in neuem Tab oeffnen"
* Die URL aus dem neuen Browsertab ist die direkte URL zum Bild und kann im `<img>` Tag verwendet werden